### PR TITLE
fixed "memory leak"

### DIFF
--- a/crEAP.py
+++ b/crEAP.py
@@ -233,7 +233,7 @@ else:
 		live()
 		print bcolors.WARNING + "\n[-]"+ bcolors.ENDC + " Sniffing for EAPOL packets on "+adapter+" channel "+channel+"...  "+ bcolors.FAIL + "Ctrl+C to exit" + bcolors.ENDC
 		conf.iface = adapter
-		sniff(iface=adapter, prn=eapol_header)
+		sniff(iface=adapter, prn=eapol_header, store=0)
 		print "\n" + bcolors.FAIL + "\n[!]" + bcolors.ENDC + " User requested interrupt, cleaning up monitor interface and exiting..."
 		print bcolors.WARNING + "[-]"+ bcolors.ENDC + " Cleaning up interfaces..."
 		subprocess.Popen("screen -X -S crEAP kill", shell=True, stdout=subprocess.PIPE).stdout.read()


### PR DESCRIPTION
fixes a "not a memory leak", sniff() by default stores sniffed packets so we need to tell him to store=0
quickly tested but shouldn't break stuff